### PR TITLE
update header to use the site.url and extra space on changelog

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,12 +39,14 @@ GEM
     ethon (0.15.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     execjs (2.8.1)
     faraday (2.4.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.1.0)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (227)
@@ -230,6 +232,8 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.8-x64-mingw32)
+      racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -265,18 +269,22 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
+    unf_ext (0.0.8.2-x64-mingw32)
     unicode-display_width (1.8.0)
+    wdm (0.1.1)
     webrick (1.7.0)
     zeitwerk (2.6.0)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   github-pages
   jekyll-get-json!
   jekyll-remote-include!
+  wdm (>= 0.1.0)
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.1.4
+   2.2.15

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 	<div class="logo">
 		<div class="appIconShadow">
 			{% if page.url != '/' %}
-				<a href="../" target="_self"><img class="headerIcon" src="{{ site.app_icon | relative_url }}"></a>
+				<a href="{{ site.url }}" target="_self"><img class="headerIcon" src="{{ site.app_icon | relative_url }}"></a>
 			{% else %}
 				<img class="headerIcon" src="{{ site.app_icon | relative_url }}">
 			{% endif %}

--- a/_pages/changelog.md
+++ b/_pages/changelog.md
@@ -6,7 +6,7 @@ include_in_header: true
 
 # Changelog
 
-{{ site.data.changelog[0].name }} contains the latest features, bug fixes and improvements . Further down the page, you can wander endlessly through the history of Raivo. Will you scroll all the way down to its birth?
+{{ site.data.changelog[0].name }} contains the latest features, bug fixes and improvements. Further down the page, you can wander endlessly through the history of Raivo. Will you scroll all the way down to its birth?
 
 <br>
 


### PR DESCRIPTION
On websites I prefer to use full urls than ../ or relative urls. These seem more reliable. 

On the change log page, there was an extra space in the sentence. 