### PR TITLE
Removed Copright.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,7 +15,3 @@ This license and copyright notice and this permission notice shall be included i
 ## Processed Format
 
 Modification, duplication, and (re)distribution of the Services in binary or published format ("Processed Format") for any purposes and/or reasons is strictly prohibited without the explicit permission from Raivo OTP. Permission for modification, duplication, and (re)distribution of the "Service" in Processed Format can be requested via [GitHub](https://github.com/raivo-otp/ios-application/issues/new?assignees=tijme&labels=Question).
-
-## Copyright
-
-Copyright © 2022 Tijme Gommers. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Special thanks to [@jerrington](https://github.com/cjerrington) and [@therealmrm
 
 ## License
 
-Copyright © 2022 Tijme Gommers. All rights reserved. View [LICENSE.md](https://github.com/raivo-otp/marketing-website/blob/master/LICENSE.md) for the full license.
+View [LICENSE.md](https://github.com/raivo-otp/marketing-website/blob/master/LICENSE.md) for the license.


### PR DESCRIPTION
The Copyright Notice still disallows the license from being valid.

Close it if you don't want to change it.