### PR TITLE
update LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,16 +4,22 @@
 
 Copyright © 2022 Tijme Gommers. All rights reserved.
 
-Raivo OTP ("us", "we", "our", "Raivo", "Tijme Gommers") operates the Raivo OTP related services (the "Services"). The Services include and are limited to the Source Format and Processed Format of [Raivo OTP for Apple iOS](https://github.com/raivo-otp/ios-application), [Raivo OTP for Apple MacOS](https://github.com/raivo-otp/macos-receiver), [Raivo OTP Issuer Icons](https://github.com/raivo-otp/issuer-icons), [Raivo OTP APNS Server](https://github.com/raivo-otp/apns-server) and [Raivo OTP Marketing Website](https://github.com/raivo-otp/marketing-website) (raivo-otp.com).
+Raivo OTP ("us", "we", "our", "Raivo", "Tijme Gommers") operates the Raivo OTP related services (the "Services"). The Services include and are limited to the Source Format and Processed Format of the [Raivo OTP for Apple iOS application](https://github.com/raivo-otp/ios-application), the [Raivo OTP for Apple MacOS application](https://github.com/raivo-otp/macos-receiver), the [Raivo OTP Icons Issuer service](https://github.com/raivo-otp/issuer-icons), the [Raivo OTP APNS Server](https://github.com/raivo-otp/apns-server) and the [Raivo OTP Marketing Website](https://github.com/raivo-otp/marketing-website) (raivo-otp.com).
 
-The Services are provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the Services or the use or other dealings in the Services.
+## Warranty
+
+The Services is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the authors, licensors, or copyright holders be liable for any claim or damages whether in an action of contract, tort or otherwise, arising from, out of or in connection with the Services or the use or other dealings in the Services.
+
+## Liability
+
+The authors, licensors, or copyright holders will in no event be liable for any direct or indirect, material or moral, damages of any kind, arising out of the Licence or of the use of the Work, including without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, loss of data or any commercial damage, even if the authors, licensors, or copyright holders have been advised of the possibility of such damage.
 
 ## Source Format
 
-Permission is hereby granted, free of charge, to any person who obtains a copy of the Services in source format ("Source Format"), to use the Services in Source Format, subject to restrictions, to the rights to use, copy, modify, merge, and provided to allow you to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person who obtains a copy of the Services in source format ("Source Format"), to use the Services in Source Format, subject to restrictions, to the rights to use, copy, modify, merge, and provided to allow you to do so, subject to the following conditions: 
 
-This license and copyright notice and this permission notice shall be included in all copies or substantial portions of the Services. Any form of Processed Format arising from the Source Format shall be used as specified in section [Processed Format](#processed-format). 
+'This license and ® copyright notice and this permission notice shall be included in all copies or substantial portions of the Services. Any form of Processed Format arising from the Source Format shall be used as specified in section [Processed Format](#processed-format).'
 
 ## Processed Format
 
-Modification, duplication, and (re)distribution of the Services in binary or published format ("Processed Format") for any purposes and/or reasons is strictly prohibited without the explicit permission from Raivo OTP. Permission for modification, duplication, and (re)distribution of the "Service" in Processed Format can be requested via [GitHub](https://github.com/raivo-otp/ios-application/issues/new?assignees=tijme&labels=Question).
+[commercial use](https://en.wikipedia.org/wiki/Commercial_use_of_space), [patent use]( https://en.wikipedia.org/wiki/Patent), and [redistribution](https://en.wikipedia.org/wiki/Redistribution) of the Services in binary or published format ("Processed Format") for any purposes and/or reasons is strictly prohibited without the explicit consent from us. Permission for commercial use, patent use, and re-distribution of the "Service" in Processed Format can be requested via a [GitHub](https://github.com/raivo-otp/ios-application/issues/new?assignees=tijme&labels=Question) issue. 


### PR DESCRIPTION
- Added a dedicate liability section to the license.
- Changed the "processed format" cover commercial use, patent use, and redistribution of the service, instead of modification and duplication of the service (seen as it has already been allowed in the "source format" selection of the license).