### PR TITLE
Fixed Unbounded resource exhaustion in cmark-gfm autolink extension may lead to denial of service

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.5)
+    commonmarker (0.23.6)
     concurrent-ruby (1.1.10)
     deep_merge (1.2.2)
     dnsruby (1.61.9)


### PR DESCRIPTION
## 👾 Describe The Sumarry:
CommonMarker uses cmark-gfm for rendering [Github Flavored Markdown](https://github.github.com/gfm/). A polynomial time complexity issue in cmark-gfm's autolink extension may lead to unbounded resource exhaustion and subsequent denial of service.



## 🥷 According CVeScores:
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)

**Refferences:**
https://github.com/gjtorikian/commonmarker/pull/190
https://en.wikipedia.org/wiki/Time_complexity